### PR TITLE
Update osd_core.c - Add  10s timeout before speed warner talks to you

### DIFF
--- a/navit/osd/core/osd_core.c
+++ b/navit/osd/core/osd_core.c
@@ -2497,6 +2497,7 @@ struct osd_speed_warner {
 	int bTextOnly;
 	struct graphics_image *img_active,*img_passive,*img_off;
 	char* label_str;
+	int wait_before_warn;
 };
 
 static void
@@ -2562,8 +2563,14 @@ osd_speed_warner_draw(struct osd_priv_common *opc, struct navit *navit, struct v
             if( this->speed_exceed_limit_offset+routespeed<tracking_speed &&
                 (100.0+this->speed_exceed_limit_percent)/100.0*routespeed<tracking_speed ) {
                 if(this->announce_state==eNoWarn && this->announce_on) {
-                    this->announce_state=eWarningTold; //warning told
-                    navit_say(navit,_("Please decrease your speed"));
+                    wait_before_warn++;
+                    if(wait_before_warn > 10){
+                    	this->announce_state=eWarningTold; //warning told
+                    	navit_say(navit,_("Please decrease your speed"));
+                    }
+                }else{
+                	/* reset speed warning */
+                    	wait_before_warn = 0;	
                 }
             }
             if( tracking_speed <= routespeed ) {
@@ -2619,7 +2626,7 @@ osd_speed_warner_init(struct osd_priv_common *opc, struct navit *nav)
 	if (opc->osd_item.h < this->d)
 		this->d=opc->osd_item.h;
 	this->width=this->d/10;
-
+	this->wait_before_warn = 0;
         if(this->label_str && !strncmp("images:",this->label_str,7)) {
           char *tok1=NULL, *tok2=NULL, *tok3=NULL;
           strtok(this->label_str,":");

--- a/navit/osd/core/osd_core.c
+++ b/navit/osd/core/osd_core.c
@@ -2563,14 +2563,14 @@ osd_speed_warner_draw(struct osd_priv_common *opc, struct navit *navit, struct v
             if( this->speed_exceed_limit_offset+routespeed<tracking_speed &&
                 (100.0+this->speed_exceed_limit_percent)/100.0*routespeed<tracking_speed ) {
                 if(this->announce_state==eNoWarn && this->announce_on) {
-                    wait_before_warn++;
-                    if(wait_before_warn > 10){
+                    this->wait_before_warn++;
+                    if(this->wait_before_warn > 10){
                     	this->announce_state=eWarningTold; //warning told
                     	navit_say(navit,_("Please decrease your speed"));
                     }
                 }else{
                 	/* reset speed warning */
-                    	wait_before_warn = 0;	
+                    	this->wait_before_warn = 0;	
                 }
             }
             if( tracking_speed <= routespeed ) {


### PR DESCRIPTION
When max_speed changes while driving, the speed warner often announces unless I am decreasing speed. So I'd want to navit wait a little before complaining about my speed.

Another point is, that if navit places me on a road next to the e.g. highway/Autobahn I am currently on, it complains a lot while I am not breaking the speed limit on the road I am really on.
